### PR TITLE
Add access token - so we can access it

### DIFF
--- a/Sources/Client/Server.swift
+++ b/Sources/Client/Server.swift
@@ -57,6 +57,15 @@ open class Server: FHIROpenServer, OAuth2RequestPerformer {
 		get { return auth?.oauth?.idToken }
 	}
 	
+	// Also keep track of access token
+	public var accessToken: String? {
+	        get { return auth?.oauth?.accessToken }
+	}
+
+	public var accessTokenExpiry: Date? {
+	        get { return auth?.oauth?.accessTokenExpiry }
+	}
+	
 	/// The refresh token provided with the access token; Issuing a refresh token is optional at the discretion of the authorization server.
 	public var refreshToken: String? {
 		get { return auth?.oauth?.refreshToken }


### PR DESCRIPTION
- We also need to be able to access the accessToken attribute

Let's try to use this SMART pod instead.

cc @LearningMotors/algoworks 